### PR TITLE
build platform-defined dynamic library instead of Rust library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "MIT/Apache-2.0"
 [lib]
 name = "sovrin"
 path = "src/lib.rs"
+crate-type = ["dylib"]
 
 [[bin]]
 name = "sovrin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "Sovrin client with c-callable interface"
 license = "MIT/Apache-2.0"
 
 [lib]
-name = "libsovrin"
+name = "sovrin"
 path = "src/lib.rs"
 
 [[bin]]


### PR DESCRIPTION
this will build "libsovrin.so" instead of "liblibsovrin.rlib"