### PR TITLE
Fixed build after switching to dylib create type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT/Apache-2.0"
 [lib]
 name = "sovrin"
 path = "src/lib.rs"
-crate-type = ["dylib"]
+crate-type = ["rlib", "dylib"]
 
 [[bin]]
 name = "sovrin"

--- a/tests/api_pool.rs
+++ b/tests/api_pool.rs
@@ -1,4 +1,4 @@
-extern crate libsovrin;
+extern crate sovrin;
 
 #[macro_use]
 extern crate lazy_static;
@@ -6,8 +6,8 @@ extern crate lazy_static;
 #[path = "utils/mod.rs"]
 mod utils;
 
-use libsovrin::api::ErrorCode;
-use libsovrin::api::pool::sovrin_create_pool_ledger;
+use sovrin::api::ErrorCode;
+use sovrin::api::pool::sovrin_create_pool_ledger;
 
 use utils::callbacks::CallbacksHelpers;
 

--- a/tests/utils/callbacks.rs
+++ b/tests/utils/callbacks.rs
@@ -1,7 +1,6 @@
 use std::sync::Mutex;
 
-use libsovrin::api::ErrorCode;
-
+use sovrin::api::ErrorCode;
 
 pub struct CallbacksHelpers {}
 


### PR DESCRIPTION
* Use both create types "rlib", "dylib"
* Fixing integration tests after renaming of lib create