### PR TITLE
add windows build with precompiled binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ authors = [
 
 description = "Sovrin client with c-callable interface"
 license = "MIT/Apache-2.0"
+build = "build.rs"
 
 [lib]
 name = "sovrin"
@@ -38,7 +39,7 @@ env_logger = "0.4.2"
 libc = "0.2.21"
 log = "0.3.7"
 openssl = { version = "0.9.11", optional = true }
-milagro-crypto = { version = "0.1.6", optional = true }
+milagro-crypto = { version = "0.1.7", optional = true }
 rand = "0.3"
 rusqlite = "0.10.1"
 rust-base58 = {version = "0.0.4", optional = true}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # sovrin-client-rust
+
+# Windows build
+
+- Get binary dependencies (libamcl*, openssl, libsodium, libzmq, sqlite3).
+- Put all *.{lib,dll} into one directory and headers into include/ subdirectory.
+- Point path to this directory using environment variables:
+  - set SOVRIN_PREBUILT_DEPS_DIR=C:\BIN\x64
+  - set SODIUM_STATIC=y
+  - set SODIUM_LIB_DIR=C:\BIN\x64
+  - set OPENSSL_INCLUDE_DIR=C:\BIN\x64\include
+  - set OPENSSL_LIB_DIR=C:\BIN\x64
+  - set LIBZMQ_LIB_DIR=C:\BIN\x64
+  - set LIBZMQ_INCLUDE_DIR=C:\BIN\x64\include
+- open MSVS development console
+- execute "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+- change dir to sovrin-client and run
+  - "cargo test" or
+  - cargo test --release --target x86_64-pc-windows-msvc

--- a/README.md
+++ b/README.md
@@ -4,16 +4,15 @@
 
 - Get binary dependencies (libamcl*, openssl, libsodium, libzmq, sqlite3).
 - Put all *.{lib,dll} into one directory and headers into include/ subdirectory.
+- open MSVS development console
+- execute "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 - Point path to this directory using environment variables:
   - set SOVRIN_PREBUILT_DEPS_DIR=C:\BIN\x64
-  - set SODIUM_STATIC=y
   - set SODIUM_LIB_DIR=C:\BIN\x64
   - set OPENSSL_INCLUDE_DIR=C:\BIN\x64\include
   - set OPENSSL_LIB_DIR=C:\BIN\x64
   - set LIBZMQ_LIB_DIR=C:\BIN\x64
   - set LIBZMQ_INCLUDE_DIR=C:\BIN\x64\include
-- open MSVS development console
-- execute "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-- change dir to sovrin-client and run
-  - "cargo test" or
-  - cargo test --release --target x86_64-pc-windows-msvc
+- set static flag for libsodium build
+  - set SODIUM_STATIC=y
+- change dir to sovrin-client and run cargo (you may want to add --release --target x86_64-pc-windows-msvc keys to cargo)

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+    println!("target={}", target);
+    match target.find("-windows-") {
+        Some(..) => {
+	    // do not build c-code on windows, use binaries
+	    let output_dir = env::var("OUT_DIR").unwrap();
+	    let prebuilt_dir = env::var("SOVRIN_PREBUILT_DEPS_DIR").unwrap();
+
+	    let dst = Path::new(&output_dir[..]).join("..\\..\\..");
+	    let prebuilt = Path::new(&prebuilt_dir[..]);
+
+	    println!("cargo:rustc-link-search=native={}", prebuilt_dir);
+            println!("cargo:rustc-flags=-L {}/lib", prebuilt_dir);
+            println!("cargo:include={}/include", prebuilt_dir);
+
+	    let files = vec![ "libeay32md.dll", "libsodium.dll", "libzmq.dll", "ssleay32md.dll" ];
+	    for f in files.iter() {
+	        if let Ok(_) = fs::copy(&prebuilt.join(f), &dst.join(f)) {
+	            println!("copy {} -> {}", &prebuilt.join(f).display(), &dst.join(f).display());
+		}
+	    }
+	    return;
+        },
+        None => {}
+    }
+}


### PR DESCRIPTION
You need to put binary deps and point them using SOVRIN_PREBUILT_DEPS_DIR environment variable.
Also ~/.cargo/.../openssl-sys.../build.rs must be patched adding gdi32.lib.